### PR TITLE
Fixed name of Desert crate

### DIFF
--- a/ScorchedEarth/OUTPUT_FORMAT_SCORCHEDEARTH
+++ b/ScorchedEarth/OUTPUT_FORMAT_SCORCHEDEARTH
@@ -10,4 +10,4 @@ ConfigOverrideSupplyCrateItems=(SupplyCrateClassString="SupplyCrate_Level55_Scor
 ConfigOverrideSupplyCrateItems=(SupplyCrateClassString="SupplyCrate_Level55_Double_ScorchedEarth_C",MinItemSets=2,MaxItemSets=3,NumItemSetsPower=1.4,bSetsRandomWithoutReplacement=true,%lvl55beacon_yellow_scorchedearth%)
 ConfigOverrideSupplyCrateItems=(SupplyCrateClassString="SupplyCrate_Level70_ScorchedEarth_C",MinItemSets=1,MaxItemSets=2,NumItemSetsPower=1.0,bSetsRandomWithoutReplacement=true,%lvl70beacon_red_scorchedearth%)
 ConfigOverrideSupplyCrateItems=(SupplyCrateClassString="SupplyCrate_Level70_Double_ScorchedEarth_C",MinItemSets=2,MaxItemSets=3,NumItemSetsPower=1.4,bSetsRandomWithoutReplacement=true,%lvl70beacon_red_scorchedearth%)
-ConfigOverrideSupplyCrateItems=(SupplyCrateClassString="SupplyCrate_OceanInstant_C",MinItemSets=1,MaxItemSets=1,NumItemSetsPower=2.4,bSetsRandomWithoutReplacement=true,%lvl80beacon_sand_scorchedearth%)
+ConfigOverrideSupplyCrateItems=(SupplyCrateClassString="SupplyCreate_OceanInstant_High_C",MinItemSets=1,MaxItemSets=1,NumItemSetsPower=2.4,bSetsRandomWithoutReplacement=true,%lvl80beacon_sand_scorchedearth%)


### PR DESCRIPTION
SupplyCrate_OceanInstant_C is used for underwater crates on TheIsland. For overriding desert crates on ScorchedEart we should use SupplyCreate_OceanInstant_High_C